### PR TITLE
fix(help)!: the decorator decides visibility, not default_permissions or a description string

### DIFF
--- a/cogs/core/admin.py
+++ b/cogs/core/admin.py
@@ -23,7 +23,7 @@ class Admin(commands.Cog):
     @commands.command(name="addsuperadmin", hidden=True)
     @commands.check(is_superadmin)
     async def addsuperadmin(self, ctx, member: discord.Member = None):
-        """Add a user as a bot superadmin (owner only)."""
+        """Add a user as a bot superadmin."""
         if not member:
             await ctx.send("Please specify a user to add as bot superadmin.")
             self.logger.warning(f"addsuperadmin called without member by {ctx.author} (ID: {ctx.author.id})")
@@ -119,7 +119,7 @@ class Admin(commands.Cog):
     @commands.command(name="removesuperadmin", hidden=True)
     @commands.check(is_superadmin)
     async def removesuperadmin(self, ctx, user: discord.User = None):
-        """Remove a user from the global bot superadmins (superadmin only)."""
+        """Remove a user from the global bot superadmins."""
         if not user:
             await ctx.send("Please specify a user to remove as bot superadmin.")
             self.logger.warning(f"removesuperadmin called without member by {ctx.author} (ID: {ctx.author.id})")

--- a/cogs/core/control.py
+++ b/cogs/core/control.py
@@ -5,7 +5,8 @@ from sys import version_info as sysv
 import subprocess
 from datetime import datetime
 import sys
-from core.utils import InvokerOnlyView, is_superadmin, safe_delete, list_cog_modules
+from core.utils import (InvokerOnlyView, app_is_superadmin, is_superadmin,
+                        safe_delete, list_cog_modules)
 
 class Control(commands.Cog):
     """The bot's runtime control plane, superadmin-only: cog
@@ -359,10 +360,15 @@ class Control(commands.Cog):
             await message.edit(content=f'An error has occurred: {exc}', delete_after=20)
 
     @app_commands.command(name="cogs",
-                          description="Open the cog-management panel (superadmin)")
+                          description="Open the cog-management panel")
+    @app_is_superadmin()
     async def cogs_slash(self, interaction: discord.Interaction):
-        """Ephemeral twin of `!cogs` (#76). No default_permissions — the gate
-        is the bot's own superadmin list, not Discord permissions."""
+        """Ephemeral twin of `!cogs` (#76). The gate is the bot's own
+        superadmin list, not Discord permissions, so it rides on
+        @app_is_superadmin rather than default_permissions — that keeps the
+        decorator authoritative for both enforcement and /help visibility.
+        The body check stays as defense in depth and to render the friendly
+        denial for anyone who invokes past a stale client cache."""
         if not is_superadmin(interaction):
             await interaction.response.send_message(
                 "Requires superadmin.", ephemeral=True)
@@ -373,7 +379,8 @@ class Control(commands.Cog):
         view.message = None
 
     @app_commands.command(name="config",
-                          description="Open the global-config editor (superadmin)")
+                          description="Open the global-config editor")
+    @app_is_superadmin()
     async def config_slash(self, interaction: discord.Interaction):
         """Ephemeral twin of `!config` (#76).
 

--- a/cogs/optional/auto_response.py
+++ b/cogs/optional/auto_response.py
@@ -30,7 +30,7 @@ from discord import app_commands
 import random
 import re
 
-from core.utils import InvokerOnlyView, is_admin
+from core.utils import InvokerOnlyView, app_is_admin, is_admin
 
 MAX_ENTRIES = 25  # Discord select-menu option cap
 
@@ -129,11 +129,15 @@ class AutoResponse(commands.Cog):
     # ---- admin UI -------------------------------------------------------
 
     @app_commands.command(name="autoresponse",
-                          description="Open the auto-response panel (admin)")
+                          description="Open the auto-response panel")
     @app_commands.guild_only()
+    @app_is_admin()
     async def autoresponse_slash(self, interaction: discord.Interaction):
-        """Ephemeral twin of `!autoresponse` (#76). No default_permissions:
-        the gate is the bot's own admin concept, not Discord permissions."""
+        """Ephemeral twin of `!autoresponse` (#76). The gate is the bot's own
+        admin concept, not Discord permissions, so it rides on @app_is_admin
+        rather than default_permissions — that keeps the decorator
+        authoritative for both enforcement and /help visibility. The body
+        check stays as defense in depth and for the friendly denial."""
         if not is_admin(interaction):
             await interaction.response.send_message(
                 "Requires admin.", ephemeral=True)

--- a/cogs/optional/error_handler.py
+++ b/cogs/optional/error_handler.py
@@ -44,7 +44,7 @@ class ErrorLoggingAdmin(commands.Cog):
 
     # ==================== TEXT COMMANDS ====================
 
-    @commands.group(name="errorlog", invoke_without_command=True)
+    @commands.group(name="errorlog", invoke_without_command=True, hidden=True)
     async def errorlog(self, ctx):
         """
         Error logging configuration commands.
@@ -55,7 +55,7 @@ class ErrorLoggingAdmin(commands.Cog):
     @errorlog.command(name="status")
     @commands.check(is_admin)
     async def errorlog_status(self, ctx):
-        """Show current error logging configuration. Requires: Guild admin or superadmin"""
+        """Show current error logging configuration."""
         if not ctx.guild:
             await ctx.send("This command must be run in a guild.")
             return
@@ -138,7 +138,6 @@ class ErrorLoggingAdmin(commands.Cog):
         """
         Set the default error logging channel for this guild.
         Usage: !errorlog setchannel #channel
-        Requires: Guild admin or superadmin
         """
         if not ctx.guild:
             await ctx.send("This command must be run in a guild.")
@@ -204,7 +203,6 @@ class ErrorLoggingAdmin(commands.Cog):
         Route a specific error category to a channel for this guild.
         Categories: command_error, event_error, task_error, other
         Usage: !errorlog setcategory command_error #channel
-        Requires: Guild admin or superadmin
         """
         if not ctx.guild:
             await ctx.send("This command must be run in a guild.")
@@ -241,7 +239,6 @@ class ErrorLoggingAdmin(commands.Cog):
         Route a specific severity level to a channel for this guild.
         Severities: info, warning, error, critical
         Usage: !errorlog setseverity critical #channel
-        Requires: Guild admin or superadmin
         """
         if not ctx.guild:
             await ctx.send("This command must be run in a guild.")
@@ -270,7 +267,7 @@ class ErrorLoggingAdmin(commands.Cog):
     @commands.check(is_superadmin)
     async def errorlog_ratelimit(self, ctx, minutes: int):
         """
-        Set the global rate limit for duplicate errors in minutes (superadmin only).
+        Set the global rate limit for duplicate errors in minutes.
         This applies to all error deduplication across all guilds.
         Usage: !errorlog ratelimit 10
         """
@@ -290,7 +287,6 @@ class ErrorLoggingAdmin(commands.Cog):
         """
         Disable error logging for this guild by removing all error config.
         Re-enable with !errorlog setchannel
-        Requires: Guild admin or superadmin
         """
         if not ctx.guild:
             await ctx.send("This command must be run in a guild.")
@@ -306,7 +302,7 @@ class ErrorLoggingAdmin(commands.Cog):
     @commands.check(is_superadmin)
     async def errorlog_setglobal(self, ctx, *, channel: str = None):
         """
-        Set or disable global error channel (superadmin only).
+        Set or disable global error channel.
         Receives errors from: cog load failures, DMs, uncaught errors, and guilds without their own config.
         Usage: !errorlog setglobal #channel
         Usage: !errorlog setglobal disable

--- a/cogs/optional/gpt.py
+++ b/cogs/optional/gpt.py
@@ -8,7 +8,7 @@ from collections import deque
 from datetime import datetime
 from typing import Dict, List, Optional, Any
 
-from core.utils import InvokerOnlyView, is_admin, is_superadmin, recursive_split
+from core.utils import InvokerOnlyView, app_is_admin, is_admin, is_superadmin, recursive_split
 from core.llm import LLMClient, PROVIDER_ALIASES, DEFAULT_PROVIDER
 from core.ops import registry
 from core.agent_loop import AGENT_OPS, resolve_bot_tools
@@ -1287,8 +1287,9 @@ class Gpt(commands.Cog):
         await self.process_askgpt(ctx, question.strip())
 
     @app_commands.command(name="aisettings",
-                          description="Open the AI settings panel (admin)")
+                          description="Open the AI settings panel")
     @app_commands.guild_only()
+    @app_is_admin()
     async def aisettings_slash(self, interaction: discord.Interaction):
         """Ephemeral twin of `!aisettings` (#76).
 

--- a/cogs/optional/help.py
+++ b/cogs/optional/help.py
@@ -7,22 +7,33 @@ grouping mechanism is the cog a command came from; no category
 abstraction to maintain. Disabling this cog (!cogs / disabled_cogs)
 removes both surfaces with zero code changes.
 
-Visibility rules:
-- prefix commands (!help): a command is listed only if the invoker could
-  actually run it — `hidden=True` ones (the admin/superadmin surface,
-  including every panel launcher) require `is_admin`, and every command
-  must additionally pass its own checks via can_run. Gating on `hidden`
-  alone used to advertise checked-but-unhidden commands to everyone.
-- prefix commands (/help): no Context exists to evaluate checks against,
-  so only the `hidden` rule applies.
-- slash commands: shown to everyone when they carry no default_permissions;
-  gated ones appear only for admin invokers.
+Visibility rule, one sentence: THE DECORATOR DECIDES. A command is listed
+only if the invoker could actually run it, and the answer comes from the
+command's own checks — never from `hidden=True` alone (an authoring hint)
+and never from a "(superadmin)" suffix in the description (a string that
+goes stale silently). Both surfaces apply the same rule:
+
+- with the matching context (a Context for !help, an Interaction for
+  /help), the checks are EXECUTED and answer exactly;
+- without it — !help cannot run an Interaction-typed predicate, /help
+  cannot run a Context-typed one — the fallback reads the tier the check
+  declares via core.utils' app_is_admin/app_is_superadmin factories, which
+  stamp `__gate__` on their predicates. A gate of unknown tier fails
+  closed (admin-or-better), never open.
+
+Two leaks this replaced: gating on `hidden` alone advertised an is_owner()
+command to every DM user, and treating `default_permissions is None` as
+"public" advertised /cogs, /config and /autoresponse to everyone, since
+their gate is this bot's admin list rather than a Discord permission.
 """
+import inspect
+
 import discord
 from discord import app_commands
 from discord.ext import commands
 
-from core.utils import is_admin
+from core.utils import (GATE_ADMIN, GATE_SUPERADMIN, gate_of, is_admin,
+                        is_superadmin)
 
 MEDIA_NOTE = "Any file in this server's media library can be posted with !<name> — admins manage it via /media"
 
@@ -44,21 +55,78 @@ def _slash_entries(cmd):
         yield (f"/{cmd.name}", cmd.description or "")
 
 
-async def _visible_to(cmd, ctx, invoker_is_admin):
+def _is_gated(cmd, cog=None):
+    """Whether anything at all restricts who may run this command.
+
+    Deliberately structural: the presence of a check, a cog-wide cog_check,
+    or Discord-level default_permissions. It never reads the description —
+    a "(superadmin)" suffix in help text is a string that goes stale and
+    must never be what decides visibility.
+    """
+    if getattr(cmd, "checks", None):
+        return True
+    if getattr(cmd, "default_permissions", None) is not None:
+        return True
+    parent = getattr(cmd, "parent", None)
+    if parent is not None and _is_gated(parent):
+        return True
+    cog = cog if cog is not None else getattr(cmd, "cog", None)
+    # A cog_check gates every command in the cog (how !errorlog is gated
+    # without any per-command decorator).
+    if cog is not None and type(cog).cog_check is not commands.Cog.cog_check:
+        return True
+    return False
+
+
+def _gate_tier(cmd):
+    """The strictest tier any of this command's checks declares, or None.
+
+    Reads the __gate__ stamp that core.utils' is_admin/is_superadmin check
+    factories leave on their predicates. This is what lets a surface that
+    cannot EXECUTE a check still know who it was meant for."""
+    tiers = set()
+    node = cmd
+    while node is not None:
+        for check in (getattr(node, "checks", None) or []):
+            tier = gate_of(check)
+            if tier:
+                tiers.add(tier)
+        node = getattr(node, "parent", None)
+    if GATE_SUPERADMIN in tiers:
+        return GATE_SUPERADMIN
+    if GATE_ADMIN in tiers:
+        return GATE_ADMIN
+    return None
+
+
+def _passes_tier(cmd, invoker_is_admin, invoker_is_superadmin):
+    """Static visibility for a gated command, used when the surface cannot
+    run the check itself. Unknown tier is treated as admin-or-better, never
+    as public — an untagged gate fails closed."""
+    tier = _gate_tier(cmd)
+    if tier == GATE_SUPERADMIN:
+        return invoker_is_superadmin
+    return invoker_is_admin
+
+
+async def _visible_to(cmd, ctx, invoker_is_admin, invoker_is_superadmin):
     """Whether a prefix command belongs in this invoker's listing.
 
     `hidden` is an authoring hint, not an authorization boundary: a command
     can be gated by a check and still ship without hidden=True (that is how
     an is_owner() command once got advertised to every DM user, who then
     ran it and got "You do not own this bot"). So the real test is the
-    command's own checks via can_run — advertise only what the invoker
-    could actually run. ctx is None for the slash surface, which has no
-    Context to run prefix-command checks against; fall back to `hidden`
-    there rather than guessing at a check's outcome.
+    command's own checks.
+
+    With a Context, can_run answers exactly. Without one (the /help path),
+    fall back to the structural test rather than assuming public — that
+    assumption is what leaked cog_check-gated commands like !errorlog.
     """
     if cmd.hidden and not invoker_is_admin:
         return False
     if ctx is None:
+        if _is_gated(cmd):
+            return _passes_tier(cmd, invoker_is_admin, invoker_is_superadmin)
         return True
     try:
         return await cmd.can_run(ctx)
@@ -68,13 +136,44 @@ async def _visible_to(cmd, ctx, invoker_is_admin):
         return False
 
 
-async def build_help_embed(bot, invoker_is_admin, ctx=None):
+async def _slash_visible_to(ac, interaction, invoker_is_admin,
+                            invoker_is_superadmin):
+    """Whether a slash command belongs in this invoker's listing.
+
+    The mirror of _visible_to. `default_permissions is None` used to stand
+    in for "public", but commands whose gate is this bot's own admin list
+    deliberately set no default_permissions — so that test advertised every
+    admin panel to everyone. Ask the decorator instead.
+
+    With an Interaction the checks run for real; !help has only a Context,
+    which an Interaction-typed predicate cannot accept, so it falls back to
+    the declared tier.
+    """
+    if not _is_gated(ac):
+        return True
+    if interaction is None:
+        return _passes_tier(ac, invoker_is_admin, invoker_is_superadmin)
+    for check in (getattr(ac, "checks", None) or []):
+        try:
+            result = check(interaction)
+            if inspect.isawaitable(result):
+                result = await result
+            if not result:
+                return False
+        except app_commands.AppCommandError:
+            return False
+    return True
+
+
+async def build_help_embed(bot, invoker_is_admin, ctx=None,
+                           invoker_is_superadmin=False, interaction=None):
     """One monolithic embed: a field per cog, commands listed inside."""
     # Slash-command ownership: which cog registered each top-level command.
     slash_by_cog = {}
     for cog in bot.cogs.values():
         for ac in cog.get_app_commands():
-            if invoker_is_admin or ac.default_permissions is None:
+            if await _slash_visible_to(ac, interaction, invoker_is_admin,
+                                       invoker_is_superadmin):
                 slash_by_cog.setdefault(cog.qualified_name, []).append(ac)
 
     embed = discord.Embed(
@@ -86,7 +185,8 @@ async def build_help_embed(bot, invoker_is_admin, ctx=None):
         cog = bot.cogs[cog_name]
         entries = []
         for cmd in sorted(cog.get_commands(), key=lambda c: c.name):
-            if not await _visible_to(cmd, ctx, invoker_is_admin):
+            if not await _visible_to(cmd, ctx, invoker_is_admin,
+                                     invoker_is_superadmin):
                 continue
             entries.append((f"!{cmd.name}", cmd.short_doc or ""))
         for ac in slash_by_cog.get(cog_name, []):
@@ -126,7 +226,10 @@ class Help(commands.Cog):
 
     @app_commands.command(name="help", description="Overview of the bot's commands")
     async def slash_help(self, interaction: discord.Interaction):
-        embed = await build_help_embed(self.bot, is_admin(interaction))
+        embed = await build_help_embed(
+            self.bot, is_admin(interaction),
+            invoker_is_superadmin=is_superadmin(interaction),
+            interaction=interaction)
         await interaction.response.send_message(embed=embed, ephemeral=True)
 
     @commands.command(name="help")
@@ -136,7 +239,9 @@ class Help(commands.Cog):
         # public, so an admin running !help in a busy channel does print
         # the admin command names where everyone can read them. /help
         # (ephemeral) is the discreet variant.
-        embed = await build_help_embed(self.bot, is_admin(ctx), ctx)
+        embed = await build_help_embed(
+            self.bot, is_admin(ctx), ctx,
+            invoker_is_superadmin=is_superadmin(ctx))
         await ctx.send(embed=embed)
 
 

--- a/cogs/optional/media.py
+++ b/cogs/optional/media.py
@@ -7,7 +7,7 @@ from discord import File, app_commands
 import yt_dlp
 import requests
 from core.error_handler import register_error_whitelist_hook, unregister_error_whitelist_hook
-from core.utils import InvokerOnlyView, is_admin
+from core.utils import InvokerOnlyView, app_is_admin, is_admin
 
 
 def _format_size(num_bytes):
@@ -204,11 +204,14 @@ class Media(commands.Cog):
     # ---- admin UI -------------------------------------------------------
 
     @app_commands.command(name="media",
-                          description="Open the media-library panel (admin)")
+                          description="Open the media-library panel")
     @app_commands.guild_only()
+    @app_is_admin()
     async def media_slash(self, interaction: discord.Interaction):
-        """Ephemeral twin of `!media` (#76). No default_permissions: the
-        gate is the bot's own admin concept, not Discord permissions."""
+        """Ephemeral twin of `!media` (#76). The gate is the bot's own admin
+        concept, not Discord permissions, so it rides on @app_is_admin rather
+        than default_permissions — keeping the decorator authoritative for
+        both enforcement and /help visibility."""
         if not is_admin(interaction):
             await interaction.response.send_message(
                 "Requires admin.", ephemeral=True)

--- a/cogs/optional/tools.py
+++ b/cogs/optional/tools.py
@@ -14,7 +14,7 @@ class Tools(commands.Cog):
         self.bot = bot
         self.start_time = datetime.datetime.now(datetime.timezone.utc)
 
-    @commands.command(name='echo')
+    @commands.command(name='echo', hidden=True)
     @commands.check(is_admin)
     async def echo(self, ctx, *, message):
         """Repost the given text as the bot (admin only — deleting the

--- a/core/utils.py
+++ b/core/utils.py
@@ -145,6 +145,45 @@ def is_admin(config_or_ctx: Any, maybe_ctx: Any = None) -> bool:
     return False
 
 
+# Gate tiers, stamped onto check predicates by the factories below so a
+# listing can ask "what does this command require?" without running it.
+GATE_ADMIN = "admin"
+GATE_SUPERADMIN = "superadmin"
+
+
+def gate_of(check) -> Union[str, None]:
+    """The tier a check predicate declares, or None if it doesn't say.
+
+    Reading this off the decorator is what lets !help — which has a Context
+    and so cannot evaluate an app-command predicate typed for Interaction —
+    still render the right listing. An untagged check is treated as gated
+    but of unknown tier by callers, never as public."""
+    return getattr(check, "__gate__", None)
+
+
+def app_is_admin():
+    """`@app_commands.check` form of is_admin, tagged with its tier.
+
+    Slash commands whose gate is this bot's admin list (not Discord's
+    permissions) must NOT use @app_commands.default_permissions: that field
+    means something different, and a listing reading it would either hide
+    the command from people who can run it or show it to people who can't.
+    Declaring the real gate here keeps enforcement and visibility on the
+    same decorator, so they cannot drift."""
+    async def predicate(interaction) -> bool:
+        return is_admin(interaction)
+    predicate.__gate__ = GATE_ADMIN
+    return discord.app_commands.check(predicate)
+
+
+def app_is_superadmin():
+    """`@app_commands.check` form of is_superadmin, tagged with its tier."""
+    async def predicate(interaction) -> bool:
+        return is_superadmin(interaction)
+    predicate.__gate__ = GATE_SUPERADMIN
+    return discord.app_commands.check(predicate)
+
+
 def list_cog_modules(group: str, config=None) -> List[str]:
     """Loadable cog modules for a cogs/ group, as dotted module paths
     (['cogs.optional.gpt', ...]). THE one owner of the loadable-cog rule


### PR DESCRIPTION
## The bug

A non-admin's `/help` listed this:

```
/autoresponse — Open the auto-response panel (admin)
/cogs         — Open the cog-management panel (superadmin)
/config       — Open the global-config editor (superadmin)
```

Clicking one returns "Requires superadmin." The enforcement was always correct — only the listing leaked.

**Root cause:** the slash filter tested `ac.default_permissions is None` as a proxy for "public". But these commands *deliberately* set no `default_permissions`, because that field means **Discord** permissions and their gate is this bot's **own admin list**, checked in the command body. The filter read "no Discord permission requirement" as "anyone may see it."

So authorization lived where no listing could see it, and a `(superadmin)` suffix in the description was the only user-visible signal — a string with nothing keeping it true.

## The fix: the decorator is the arbiter

- **`core/utils.py`** gains `app_is_admin()` / `app_is_superadmin()` check factories that stamp `__gate__` on their predicate. A surface can now ask *what does this require* without executing anything.
- The five in-body checks (`/cogs`, `/config`, `/autoresponse`, `/media`, `/aisettings`) are lifted onto those decorators. **The body checks stay** — defense in depth, and they preserve the friendly ephemeral denial instead of a raw `CheckFailure`.
- **`help.py`** gains `_slash_visible_to`, the mirror of `_visible_to`. With an Interaction the checks execute for real; without one (`!help` cannot run an Interaction-typed predicate) the declared tier answers. An untagged gate **fails closed** — admin-or-better, never public.
- `build_help_embed` takes `invoker_is_superadmin`, adding the tier that never existed on the slash side. A guild admin no longer sees superadmin-only panels.

## Second leak, also closed

`_visible_to`'s `ctx is None` path returned `True` for every non-hidden command — so `/help` advertised `!errorlog` (gated by a cog-wide `cog_check`, no `hidden=True`) to everyone, while `!help` correctly hid it. The same user got different answers from the two surfaces. Both now apply the structural test.

## Verified

Rendered all three listings against a real bot with all 18 cogs loaded:

| | regular | admin | superadmin |
|---|---|---|---|
| `/cogs`, `/config` | ✗ | ✗ | ✓ |
| `/autoresponse`, `/media`, `/aisettings` | ✗ | ✓ | ✓ |
| `!errorlog` | ✗ | ✓ | ✓ |
| `/help`, `!ping` | ✓ | ✓ | ✓ |

## Also

Gate info stripped from 13 description/docstring strings — the decorator carries it now. `hidden=True` added to `!errorlog` and `!echo` so the authoring hint matches reality.

## Breaking

`build_help_embed` gains two keyword params. Slash descriptions lose their `(admin)`/`(superadmin)` suffixes, so **the command tree needs a re-sync** (`!sync`) for Discord to pick up the new text.